### PR TITLE
Fix GOB extractor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 __history/
 __recovery/
+*.exe
+*.wdp
+*.gob
+*.txt

--- a/wdfuse/G_Util.pas
+++ b/wdfuse/G_Util.pas
@@ -12,14 +12,14 @@ CONST
 
 TYPE
  GOB_BEGIN = record     {size 8}
-   GOB_MAGIC : array[1..4] of char;
+   GOB_MAGIC : array[1..4] of AnsiChar;
    MASTERX   : LongInt;
  end;
 
  GOB_INDEX = record     {size 21}
    IX        : LongInt;
    LEN       : LongInt;
-   NAME      : array[0..12] of char;
+   NAME      : array[0..12] of AnsiChar;
  end;
 
 
@@ -209,7 +209,7 @@ var i       : LongInt;
     S_NAME  : String;
     position  : LongInt;
     OldCursor : HCursor;
-    Buffer  : array[0..4095] of Char;
+    Buffer  : array[0..4095] of AnsiChar; //Char;
 begin
  OldCursor := SetCursor(LoadCursor(0, IDC_WAIT));
  gf := FileOpen(GOBName, fmOpenRead);
@@ -261,15 +261,15 @@ var i       : LongInt;
     MASTERN : LongInt;
     gs      : GOB_BEGIN;
     gx      : GOB_INDEX;
-    gf      : Integer;
+    gf      : LongInt;
     fsf     : Integer;
     fs_NAME : String;
     S_NAME  : String;
     position  : LongInt;
-    tmp,tmp2  : array[0..127] of Char;
+    tmp,tmp2  : array[0..127] of char;
     go        : Boolean;
     OldCursor : HCursor;
-    Buffer  : array[0..4095] of Char;
+    Buffer  : array[0..4095] of AnsiChar;
     XList   : TStrings;
 begin
  OldCursor := SetCursor(LoadCursor(0, IDC_WAIT));
@@ -302,6 +302,7 @@ begin
  FileRead(gf, gs, SizeOf(gs));
  FileSeek(gf, gs.MASTERX, 0);
  FileRead(gf, MASTERN, 4);
+
  for i := 1 to MASTERN do
    begin
      FileRead(gf, gx, SizeOf(gx));

--- a/wdfuse/M_maput.pas
+++ b/wdfuse/M_maput.pas
@@ -381,7 +381,8 @@ begin
   DO_GetMapLimits(minX, minY, minZ, maxX, maxY, maxZ);
   Xoffset := Round((minX + maxX) / 2);
   Zoffset := Round((minZ + maxZ) / 2);
-  DO_Set_ScrollBars_Ranges(round(minX), round(maxX), round(minZ), round(maxZ));
+  // TODO(azurda): This does not play nicely.
+  // DO_Set_ScrollBars_Ranges(round(minX), round(maxX), round(minZ), round(maxZ));
   MapWindow.Map.Invalidate;
 end;
 
@@ -396,10 +397,11 @@ begin
  MapWindow.HScrollBar.SetParams(XOffset, HLeft, HRight);
  MapWindow.VScrollBar.SetParams(-ZOffset, Vup, Vbottom);
  MapWindow.LScrollBar.SetParams(-LAYER, -LAYER_MAX, -LAYER_MIN);
- MapWindow.HScrollBar.SmallChange := Trunc(1+25/scale);
- MapWindow.HScrollBar.LargeChange := Trunc(1+100/scale);
- MapWindow.VScrollBar.SmallChange := Trunc(1+25/scale);
- MapWindow.VScrollBar.LargeChange := Trunc(1+100/scale);
+
+ MapWindow.HScrollBar.SmallChange := SmallInt(Trunc(1+25/scale));
+ MapWindow.HScrollBar.LargeChange := SmallInt(Trunc(1+100/scale));
+ MapWindow.VScrollBar.SmallChange := SmallInt(Trunc(1+25/scale));
+ MapWindow.VScrollBar.LargeChange := SmallInt(Trunc(1+100/scale));
 end;
 
 procedure DO_GetMapLimits(VAR minX, minY, minZ, maxX, maxY, maxZ : Real);


### PR DESCRIPTION
Delphi has changed the default of AnsiChar to WideChar (Unicode) so every extraction that relies on the size of a WideChar is wrong now. Headers were miscalculated so no extraction took place. 

`GOB_MAGIC` and `GOB_INDEX` are expected as `array of[] AnsiChar`
`Buffer`'s are also expected as ^ 

tmporary storage for debugging `tmp` in the code can remain as char.

This PR is able to create a project and allow the level editor to begin. 

![image](https://user-images.githubusercontent.com/8579024/120101345-f8712180-c145-11eb-8bdd-b7eedc268ea7.png)

![image](https://user-images.githubusercontent.com/8579024/120101327-e4c5bb00-c145-11eb-91e1-d7c298e7471c.png)


